### PR TITLE
Pacify Xcode

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "jspahrsummers/xcconfigs" >= 0.7
+github "jspahrsummers/xcconfigs" >= 0.7.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "ReactiveCocoa/ReactiveCocoa" "v2.4.3"
-github "jspahrsummers/xcconfigs" "0.7"
+github "jspahrsummers/xcconfigs" "0.7.1"

--- a/RockemSockem.xcodeproj/project.pbxproj
+++ b/RockemSockem.xcodeproj/project.pbxproj
@@ -493,7 +493,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "Josh Abernathy";
 			};
 			buildConfigurationList = 885BB8E817237A700077DC8F /* Build configuration list for PBXProject "RockemSockem" */;
@@ -642,6 +642,7 @@
 			baseConfigurationReference = 882438ED177B7EDC0071C196 /* Debug.xcconfig */;
 			buildSettings = {
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-Wall",
 					"-Werror",

--- a/RockemSockem.xcodeproj/xcshareddata/xcschemes/RockemSockem.xcscheme
+++ b/RockemSockem.xcodeproj/xcshareddata/xcschemes/RockemSockem.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
For https://github.com/jspahrsummers/xcconfigs/pull/32.

And I know what you’re thinking, “But `ONLY_ACTIVE_ARCH` is already in the xcconfig!” Yes. Well. Xcode.